### PR TITLE
Ignore empty input in the Command Box

### DIFF
--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -101,6 +101,9 @@ public class CommandBox extends UiPart<Region> {
     @FXML
     private void handleCommandInputChanged() {
         try {
+            if (commandTextField.getText().equals("")) {
+                return;
+            }
             CommandResult commandResult = logic.execute(commandTextField.getText());
             initHistory();
             historySnapshot.next();


### PR DESCRIPTION
Added a clause to check for empty input in the Command Box.

If input is empty, application will no longer save it in the command history and log it. Instead, the empty input will simply be ignored.

Has passed all existing JUnit tests that `master` has passed.
